### PR TITLE
Update launch profile name

### DIFF
--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "micNotify": {
+    "triggerCam": {
       "commandName": "Project"
     }
   }


### PR DESCRIPTION
## Summary
- rename `micNotify` launch profile to `triggerCam`

## Testing
- `dotnet build triggerCam.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a669219708327bb054e0eaab81961