### PR TITLE
Switch to triggerCam namespace

### DIFF
--- a/Audio/AudioRecorder.cs
+++ b/Audio/AudioRecorder.cs
@@ -1,8 +1,8 @@
 using NAudio.CoreAudioApi;
 using NAudio.Wave;
-using micNotifyUDP.Settings;
+using triggerCam.Settings;
 
-namespace micNotifyUDP.Audio
+namespace triggerCam.Audio
 {
     /// <summary>
     /// マイク入力を録音するクラス

--- a/Audio/DeviceReconnector.cs
+++ b/Audio/DeviceReconnector.cs
@@ -3,7 +3,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace micNotifyUDP.Audio
+namespace triggerCam.Audio
 {
     /// <summary>
     /// マイクデバイスの再接続を管理するクラス

--- a/Audio/MicrophoneCapture.cs
+++ b/Audio/MicrophoneCapture.cs
@@ -10,7 +10,7 @@ MicrophoneCaptureでは：
 using NAudio.Wave;
 using System;
 
-namespace micNotifyUDP.Audio
+namespace triggerCam.Audio
 {
     /// <summary>
     /// マイク入力の取得開始・停止を管理するクラス

--- a/Audio/SpeakerMicWatcher.cs
+++ b/Audio/SpeakerMicWatcher.cs
@@ -9,7 +9,7 @@ MicrophoneCaptureでは：
 using NAudio.CoreAudioApi;
 using System.Text.RegularExpressions;
 
-namespace micNotifyUDP.Audio
+namespace triggerCam.Audio
 {
     internal class WatcherManager
     {

--- a/Camera/CameraRecorder.cs
+++ b/Camera/CameraRecorder.cs
@@ -3,7 +3,7 @@ using System;
 using System.IO;
 using System.Threading;
 
-namespace micNotifyUDP.Camera
+namespace triggerCam.Camera
 {
     /// <summary>
     /// Webカメラから静止画・動画を保存するクラス

--- a/Controls/RecordingPathControl.cs
+++ b/Controls/RecordingPathControl.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Windows.Forms;
 
-namespace micNotify.Controls
+namespace triggerCam.Controls
 {
     public class RecordingPathControl : UserControl
     {

--- a/Controls/TempFileSettingsControl.cs
+++ b/Controls/TempFileSettingsControl.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Windows.Forms;
 
-namespace micNotify.Controls
+namespace triggerCam.Controls
 {
     /// <summary>
     /// 一時ファイル設定用のカスタムコントロール

--- a/Controls/ThresholdControl.cs
+++ b/Controls/ThresholdControl.cs
@@ -2,7 +2,7 @@ using System;
 using System.Drawing;
 using System.Windows.Forms;
 
-namespace micNotify.Controls
+namespace triggerCam.Controls
 {
     public class ThresholdControl : UserControl
     {

--- a/Controls/ToolStripTrackBar.cs
+++ b/Controls/ToolStripTrackBar.cs
@@ -3,7 +3,7 @@ using System.Drawing;
 using System.Windows.Forms;
 using System.Windows.Forms.Design;
 
-namespace micNotify.Controls
+namespace triggerCam.Controls
 {
     /// <summary>
     /// ToolStripに配置できるTrackBarコントロール

--- a/LogWriter/DebugTextWriter.cs
+++ b/LogWriter/DebugTextWriter.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace micNotifyUDP.LogWriter
+namespace triggerCam.LogWriter
 {
     // ===============================
     // Console.WriteLineの出力をDebug 出力にリダイレクト

--- a/LogWriter/LogRotator.cs
+++ b/LogWriter/LogRotator.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 
-namespace micNotifyUDP.LogWriter
+namespace triggerCam.LogWriter
 {
     /// <summary>
     /// ログファイルのローテーションを管理するクラス

--- a/LogWriter/SaveConsole.cs
+++ b/LogWriter/SaveConsole.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.IO;
 
-namespace micNotifyUDP.LogWriter
+namespace triggerCam.LogWriter
 {
     // ===============================
     // Console.WriteLineの出力をファイルにリダイレクト

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Net.Sockets;
 using System.Windows.Forms;
-using micNotifyUDP.Camera;
-using micNotifyUDP.Settings;
+using triggerCam.Camera;
+using triggerCam.Settings;
 
-namespace micNotifyUDP
+namespace triggerCam
 {
     internal static class Program
     {

--- a/ProgramAudio.cs
+++ b/ProgramAudio.cs
@@ -1,10 +1,10 @@
 using System.Net.Sockets;
-using micNotifyUDP.Audio;
-using micNotifyUDP.LogWriter;
-using micNotifyUDP.Settings;
-using micNotifyUDP.UDP;
+using triggerCam.Audio;
+using triggerCam.LogWriter;
+using triggerCam.Settings;
+using triggerCam.UDP;
 
-namespace micNotify
+namespace triggerCam
 {
     internal static class Program
     {

--- a/SerialTriggerListener.cs
+++ b/SerialTriggerListener.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO.Ports;
 using System.Threading;
 
-namespace micNotifyUDP
+namespace triggerCam
 {
     /// <summary>
     /// シリアルポートからトリガー文字列を受信するクラス

--- a/Settings/AppSettings.cs
+++ b/Settings/AppSettings.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 
-namespace micNotifyUDP.Settings
+namespace triggerCam.Settings
 {
     /// <summary>
     /// アプリケーション設定を管理するクラス

--- a/TrayIcon.Designer.cs
+++ b/TrayIcon.Designer.cs
@@ -1,7 +1,7 @@
 ﻿﻿using System.Windows.Forms;
-using micNotify.Controls;
+using triggerCam.Controls;
 
-namespace micNotify
+namespace triggerCam
 {
     partial class TrayIcon
     {

--- a/TrayIcon.cs
+++ b/TrayIcon.cs
@@ -6,11 +6,11 @@ using System.Linq;
 using System.Threading;
 using System.Windows.Forms;
 using System.Collections.Generic;
-using micNotifyUDP.UDP;
-using micNotifyUDP.Audio;
-using micNotifyUDP.Settings;
+using triggerCam.UDP;
+using triggerCam.Audio;
+using triggerCam.Settings;
 
-namespace micNotify
+namespace triggerCam
 {
     public partial class TrayIcon : Component
     {

--- a/UDP/CommandProcessor.cs
+++ b/UDP/CommandProcessor.cs
@@ -1,9 +1,9 @@
 using System.Net.Sockets;
 using System.Text.Json;
-using micNotifyUDP.Audio;
-using micNotifyUDP.Settings;
+using triggerCam.Audio;
+using triggerCam.Settings;
 
-namespace micNotifyUDP.UDP
+namespace triggerCam.UDP
 {
     /// <summary>
     /// 外部からのコマンドを処理するクラス
@@ -15,9 +15,9 @@ namespace micNotifyUDP.UDP
         private UdpClient udpClient;
         private string udpToIP;
         private int udpToPort;
-        private micNotify.TrayIcon? trayIcon;
+        private triggerCam.TrayIcon? trayIcon;
 
-        public CommandProcessor(WatcherManager watcherManager, UdpClient udpClient, string udpToIP, int udpToPort, AudioRecorder audioRecorder, micNotify.TrayIcon? trayIcon)
+        public CommandProcessor(WatcherManager watcherManager, UdpClient udpClient, string udpToIP, int udpToPort, AudioRecorder audioRecorder, triggerCam.TrayIcon? trayIcon)
         {
             this.watcherManager = watcherManager;
             this.udpClient = udpClient;

--- a/UDP/UdpAddressChanger.cs
+++ b/UDP/UdpAddressChanger.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Net;
 
-namespace micNotifyUDP.UDP
+namespace triggerCam.UDP
 {
     internal class UdpAddressChanger
     {


### PR DESCRIPTION
## Summary
- rename namespaces from `micNotify`/`micNotifyUDP` to `triggerCam`
- update using directives to match the new namespace

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a667e3d7c8327ae310a71bf40a284