### PR TITLE
Add platform checks for serial port usage

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Sockets;
 using System.Windows.Forms;
+using System.Runtime.InteropServices;
 using triggerCam.Camera;
 using triggerCam.Settings;
 
@@ -17,6 +18,11 @@ namespace triggerCam
         [STAThread]
         static void Main()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                MessageBox.Show("Serial ports are only supported on Windows");
+                return;
+            }
             var settings = AppSettings.Instance;
             ParseUdpAddress(settings.UdpToAddress, out udpToIP, out udpToPort);
             udpClient = new UdpClient();

--- a/SerialTriggerListener.cs
+++ b/SerialTriggerListener.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO.Ports;
 using System.Threading;
+using System.Windows.Forms;
 
 namespace triggerCam
 {
@@ -32,7 +33,15 @@ namespace triggerCam
         public void Start()
         {
             port.DataReceived += OnDataReceived;
-            port.Open();
+            try
+            {
+                port.Open();
+            }
+            catch (PlatformNotSupportedException ex)
+            {
+                LogWriter.AddErrorLog(ex, nameof(Start));
+                MessageBox.Show("Serial port is not supported on this platform.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
         }
 
         private void OnDataReceived(object sender, SerialDataReceivedEventArgs e)


### PR DESCRIPTION
## Summary
- block startup when running on non-Windows platforms
- wrap SerialPort.Open with try/catch for `PlatformNotSupportedException`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6ebc89248327b582ca5b64a89155