### PR TITLE
Add platform checks and serial port exception handling

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Sockets;
 using System.Windows.Forms;
+using System.Runtime.InteropServices;
 using triggerCam.Camera;
 using triggerCam.Settings;
 
@@ -17,6 +18,16 @@ namespace triggerCam
         [STAThread]
         static void Main()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                MessageBox.Show(
+                    "Serial features are only available on Windows.",
+                    "Platform Not Supported",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                return;
+            }
+
             var settings = AppSettings.Instance;
             ParseUdpAddress(settings.UdpToAddress, out udpToIP, out udpToPort);
             udpClient = new UdpClient();

--- a/SerialTriggerListener.cs
+++ b/SerialTriggerListener.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO.Ports;
 using System.Threading;
+using System.Windows.Forms;
 
 namespace triggerCam
 {
@@ -32,7 +33,18 @@ namespace triggerCam
         public void Start()
         {
             port.DataReceived += OnDataReceived;
-            port.Open();
+            try
+            {
+                port.Open();
+            }
+            catch (PlatformNotSupportedException)
+            {
+                MessageBox.Show(
+                    "Serial ports are not supported on this platform.",
+                    "Platform Not Supported",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
         }
 
         private void OnDataReceived(object sender, SerialDataReceivedEventArgs e)


### PR DESCRIPTION
## Summary
- check OS at startup and warn if not Windows
- notify user if serial port access is unsupported

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6fce20c083278d80040e02e7b8fb