### PR TITLE
Handle missing COM port gracefully

### DIFF
--- a/SerialTriggerListener.cs
+++ b/SerialTriggerListener.cs
@@ -45,6 +45,14 @@ namespace triggerCam
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
             }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is InvalidOperationException)
+            {
+                MessageBox.Show(
+                    "シリアル通信ポートが未接続です。設定を確認してください。",
+                    "COMポートエラー",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
         }
 
         private void OnDataReceived(object sender, SerialDataReceivedEventArgs e)


### PR DESCRIPTION
## Summary
- show a warning dialog when the serial port cannot be opened

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package dotnet-sdk-6.0 has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_684a7722795883278214701752dd249e