### PR TITLE
Improve serial port UI placeholder and layout

### DIFF
--- a/Controls/HorizontalMultiControlToolStripItem.cs
+++ b/Controls/HorizontalMultiControlToolStripItem.cs
@@ -63,6 +63,26 @@ namespace triggerCam.Controls
         }
 
         /// <summary>
+        /// ラベルを追加します
+        /// </summary>
+        /// <param name="text">ラベルのテキスト</param>
+        /// <returns>追加されたLabel</returns>
+        public Label AddLabel(string text)
+        {
+            var label = new Label
+            {
+                Text = text,
+                AutoSize = true,
+                TextAlign = ContentAlignment.MiddleRight,
+                Margin = new Padding(3, 3, 3, 3)
+            };
+
+            _flowPanel.Controls.Add(label);
+            _controls.Add(label);
+            return label;
+        }
+
+        /// <summary>
         /// ボタンを追加します
         /// </summary>
         /// <param name="text">ボタンのテキスト</param>

--- a/TrayIcon.Designer.cs
+++ b/TrayIcon.Designer.cs
@@ -35,8 +35,7 @@ namespace triggerCam
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TrayIcon));
             this.context = new ContextMenuStrip(this.components);
-            this.contextMenu_comPortContainer = new HorizontalLayoutToolStripItem("シリアルポート", 120, false);
-            this.contextMenu_baudRateContainer = new HorizontalLayoutToolStripItem("ボーレート", 100, false);
+            this.contextMenu_serialContainer = new HorizontalMultiControlToolStripItem();
             this.contextMenu_cameraControlsContainer = new HorizontalMultiControlToolStripItem();
             this.contextMenu_modeContainer = new HorizontalLayoutToolStripItem("モード:", 100);
             this.contextMenu_recordingsDirLabel = new ToolStripMenuItem();
@@ -58,8 +57,7 @@ namespace triggerCam
             this.context.BackColor = SystemColors.Window;
             this.context.ImageScalingSize = new Size(28, 28);
             this.context.Items.AddRange(new ToolStripItem[] {
-                                                        this.contextMenu_comPortContainer,
-                                                        this.contextMenu_baudRateContainer,
+                                                        this.contextMenu_serialContainer,
                                                         this.contextMenu_cameraControlsContainer,
                                                         this.contextMenu_modeContainer,
                                                         this.contextMenu_recordingsDirLabel,
@@ -76,17 +74,18 @@ namespace triggerCam
             this.context.Name = "context";
             this.context.Size = new Size(332, 158);
             //
-            // 
-            // contextMenu_comPortContainer
             //
-            this.contextMenu_comPortContainer.Name = "contextMenu_comPortContainer";
-            this.contextMenu_comPortContainer.SelectedIndexChanged += OnSettingChanged;
+            // contextMenu_serialContainer
             //
-            // contextMenu_baudRateContainer
-            //
-            this.contextMenu_baudRateContainer.Name = "contextMenu_baudRateContainer";
-            this.contextMenu_baudRateContainer.AddItems(new object[] { "9600", "19200", "38400", "115200" });
-            this.contextMenu_baudRateContainer.SelectedIndexChanged += OnSettingChanged;
+            this.contextMenu_serialContainer.Name = "contextMenu_serialContainer";
+            var labelCom = this.contextMenu_serialContainer.AddLabel("シリアルポート:");
+            this.contextMenu_comPortSelect = this.contextMenu_serialContainer.AddComboBox(120);
+            this.contextMenu_comPortSelect.Name = "contextMenu_comPortSelect";
+            this.contextMenu_comPortSelect.SelectedIndexChanged += OnSettingChanged;
+            var labelBaud = this.contextMenu_serialContainer.AddLabel("ボーレート:");
+            this.contextMenu_baudRateSelect = this.contextMenu_serialContainer.AddComboBox(100);
+            this.contextMenu_baudRateSelect.Name = "contextMenu_baudRateSelect";
+            this.contextMenu_baudRateSelect.SelectedIndexChanged += OnSettingChanged;
             //
             // contextMenu_cameraControlsContainer
             //
@@ -204,8 +203,9 @@ namespace triggerCam
         #endregion
 
         private ContextMenuStrip context;
-        private HorizontalLayoutToolStripItem contextMenu_comPortContainer;
-        private HorizontalLayoutToolStripItem contextMenu_baudRateContainer;
+        private HorizontalMultiControlToolStripItem contextMenu_serialContainer;
+        private ComboBox contextMenu_comPortSelect;
+        private ComboBox contextMenu_baudRateSelect;
         private HorizontalMultiControlToolStripItem contextMenu_cameraControlsContainer;
         private Button contextMenu_triggerSnap;
         private Button contextMenu_triggerStart;

--- a/TrayIcon.cs
+++ b/TrayIcon.cs
@@ -39,8 +39,9 @@ namespace triggerCam
 
             context.Opened += ContextOpened;
             context.Closing += ContextClosing;
-            context.Closed += (s, e) => { isContextMenuOpen = false; };            contextMenu_comPortContainer.SelectedIndexChanged += OnSettingChanged;
-            contextMenu_baudRateContainer.SelectedIndexChanged += OnSettingChanged;
+            context.Closed += (s, e) => { isContextMenuOpen = false; };            
+            contextMenu_comPortSelect.SelectedIndexChanged += OnSettingChanged;
+            contextMenu_baudRateSelect.SelectedIndexChanged += OnSettingChanged;
             contextMenu_cameraSelect.SelectedIndexChanged += OnSettingChanged;
             contextMenu_modeContainer.SelectedIndexChanged += OnModeChanged;
             contextMenu_address.TextChanged += OnAddressChanged;
@@ -55,15 +56,26 @@ namespace triggerCam
         }        private void LoadSettings()
         {
             if (settings == null) return;
-              // COMポート設定
-            contextMenu_comPortContainer.ClearItems();
-            contextMenu_comPortContainer.AddItems(SerialPort.GetPortNames());
-            contextMenu_comPortContainer.ComboBoxText = settings.ComPort;
+              // COMポート設定contextMenu_comPortSelect.Items.Clear();
+            var ports = SerialPort.GetPortNames();
+            if (ports.Length > 0)
+            {
+                contextMenu_comPortSelect.Items.AddRange(ports);
+                if (ports.Contains(settings.ComPort))
+                    contextMenu_comPortSelect.SelectedItem = settings.ComPort;
+                else
+                    contextMenu_comPortSelect.SelectedIndex = 0;
+            }
+            else
+            {
+                contextMenu_comPortSelect.Items.Add("シリアルポート");
+                contextMenu_comPortSelect.SelectedIndex = 0;
+            }
             
             // ボーレート設定
-            contextMenu_baudRateContainer.ClearItems();
-            contextMenu_baudRateContainer.AddItems(new object[] { "9600", "19200", "38400", "115200" });
-            contextMenu_baudRateContainer.ComboBoxText = settings.BaudRate.ToString();
+            contextMenu_baudRateSelect.Items.Clear();
+            contextMenu_baudRateSelect.Items.AddRange(new object[] { "9600", "19200", "38400", "115200" });
+            contextMenu_baudRateSelect.Text = settings.BaudRate.ToString();
             
             // カメラ選択の設定
             contextMenu_cameraSelect.Items.Clear();
@@ -154,8 +166,9 @@ namespace triggerCam
         }        private void contextMenu_save_Click(object sender, EventArgs e)
         {
             if (settings == null) return;
-              settings.ComPort = contextMenu_comPortContainer.ComboBoxText;
-            if (int.TryParse(contextMenu_baudRateContainer.ComboBoxText, out int br))
+            string selectedPort = contextMenu_comPortSelect.SelectedItem as string ?? "";
+            settings.ComPort = selectedPort == "シリアルポート" ? string.Empty : selectedPort;
+            if (int.TryParse(contextMenu_baudRateSelect.Text, out int br))
                 settings.BaudRate = br;
                 
             // カメラインデックスを解析


### PR DESCRIPTION
## Summary
- add `AddLabel` helper to `HorizontalMultiControlToolStripItem`
- show serial-port and baud-rate pickers side by side
- display a `シリアルポート` placeholder when no serial ports exist
- ignore the placeholder value when saving settings

## Testing
- `dotnet build -v minimal`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684abc8adcf08327bad8615f2876d6eb