### PR TITLE
Align camera, mode, and trigger controls horizontally

### DIFF
--- a/TrayIcon.Designer.cs
+++ b/TrayIcon.Designer.cs
@@ -37,7 +37,6 @@ namespace triggerCam
             this.context = new ContextMenuStrip(this.components);
             this.contextMenu_serialContainer = new HorizontalMultiControlToolStripItem();
             this.contextMenu_cameraControlsContainer = new HorizontalMultiControlToolStripItem();
-            this.contextMenu_modeContainer = new HorizontalLayoutToolStripItem("", 100, false);
             this.contextMenu_recordingsDirLabel = new ToolStripMenuItem();
             this.contextMenu_recordingsPath = new RecordingPathToolStripItem();
             this.contextMenu_openRecordingsDir = new ToolStripMenuItem();
@@ -59,7 +58,6 @@ namespace triggerCam
             this.context.Items.AddRange(new ToolStripItem[] {
                                                         this.contextMenu_serialContainer,
                                                         this.contextMenu_cameraControlsContainer,
-                                                        this.contextMenu_modeContainer,
                                                         this.contextMenu_recordingsDirLabel,
                                                         this.contextMenu_recordingsPath,
                                                         this.contextMenu_openRecordingsDir,
@@ -112,10 +110,11 @@ namespace triggerCam
             this.contextMenu_triggerStart.Visible = true;
             this.contextMenu_triggerStop.Visible = false;
             //
-            // contextMenu_modeContainer
+            // contextMenu_modeContainer (ComboBox)
             //
+            this.contextMenu_modeContainer = this.contextMenu_cameraControlsContainer.AddComboBox(100);
             this.contextMenu_modeContainer.Name = "contextMenu_modeContainer";
-            this.contextMenu_modeContainer.AddItems(new object[] { "静止画", "動画" });
+            this.contextMenu_modeContainer.Items.AddRange(new object[] { "静止画", "動画" });
             this.contextMenu_modeContainer.SelectedIndexChanged += OnModeChanged;
             //
             // contextMenu_recordingsDirLabel
@@ -209,7 +208,7 @@ namespace triggerCam
         private Button contextMenu_triggerStart;
         private Button contextMenu_triggerStop;
         private ComboBox contextMenu_cameraSelect;
-        private HorizontalLayoutToolStripItem contextMenu_modeContainer;
+        private ComboBox contextMenu_modeContainer;
         private ToolStripMenuItem contextMenu_save;
         private ToolStripMenuItem contextMenu_exit;
         private NotifyIcon notifyIcon1;

--- a/TrayIcon.cs
+++ b/TrayIcon.cs
@@ -102,8 +102,8 @@ namespace triggerCam
             }
             
             // モード設定
-            contextMenu_modeContainer.ClearItems();
-            contextMenu_modeContainer.AddItems(new object[] { "静止画", "動画" });
+            contextMenu_modeContainer.Items.Clear();
+            contextMenu_modeContainer.Items.AddRange(new object[] { "静止画", "動画" });
             contextMenu_modeContainer.SelectedIndex = 1; // デフォルトは動画モード
             
             contextMenu_recordingsPath.Path = settings.CameraSaveDirectory;


### PR DESCRIPTION
## Summary
- update context menu layout so camera select, mode select, and trigger buttons are placed on the same horizontal row

## Testing
- `dotnet build -clp:Summary --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_684ac23570e48327b2dd12bbb1f57837