### PR TITLE
Enable LogWriter-based logging

### DIFF
--- a/LogWriter/LogWriterTextWriter.cs
+++ b/LogWriter/LogWriterTextWriter.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using System.Text;
+
+namespace triggerCam.LogWriter
+{
+    internal class LogWriterTextWriter : TextWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void WriteLine(string? value)
+        {
+            global::LogWriter.AddLog(value ?? string.Empty);
+        }
+
+        public override void Write(string? value)
+        {
+            global::LogWriter.AddLog(value ?? string.Empty);
+        }
+    }
+}

--- a/LogWriter/SaveConsole.cs
+++ b/LogWriter/SaveConsole.cs
@@ -49,7 +49,8 @@ namespace triggerCam.LogWriter
             // B. MultiTextWriterによってConsole.WriteLine()を複数の出力先にリダイレクト
             // DebugTextWriter クラスを用いて Console.WriteLine() の出力を Debug 出力にリダイレクト
             DebugTextWriter debugTextWriter = new DebugTextWriter();
-            multiTextWriter = new MultiTextWriter(sw, debugTextWriter);
+            LogWriterTextWriter logWriterTextWriter = new LogWriterTextWriter();
+            multiTextWriter = new MultiTextWriter(sw, debugTextWriter, logWriterTextWriter);
 
             // B. これ以降のConsole.WriteLine()がファイルとデバッグ出力に書き込まれる
             Console.SetOut(multiTextWriter);

--- a/Program.cs
+++ b/Program.cs
@@ -38,6 +38,9 @@ namespace triggerCam
                     MessageBoxIcon.Information);
                 return;
             }
+
+            // Initialize log redirection
+            var consoleSaver = triggerCam.LogWriter.SaveConsole.Instance;
             
             var settings = AppSettings.Instance;
             
@@ -111,6 +114,7 @@ namespace triggerCam
                 StopUdpServices();
                 serialListener?.Dispose();
                 cameraRecorder?.Dispose();
+                triggerCam.LogWriter.SaveConsole.Instance.Dispose();
                 Notify("success", "disConnected");
             };
 


### PR DESCRIPTION
## Summary
- hook up console logging through new `LogWriterTextWriter`
- redirect all `Console.WriteLine` output to LogWriter at program startup

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684bad76a1408327b00d5626d1e4bada