### PR TITLE
Add camera error dialogs and recording timeout

### DIFF
--- a/LogWriter/LogRotator.cs
+++ b/LogWriter/LogRotator.cs
@@ -47,6 +47,7 @@ namespace triggerCam.LogWriter
                     catch (Exception ex)
                     {
                         Console.WriteLine($"Error deleting log file {file}: {ex.Message}");
+                        global::LogWriter.AddErrorLog(ex, nameof(RotateLogs));
                     }
                 }
 
@@ -70,6 +71,7 @@ namespace triggerCam.LogWriter
             catch (Exception ex)
             {
                 Console.WriteLine($"Error rotating logs: {ex.Message}");
+                global::LogWriter.AddErrorLog(ex, nameof(RotateLogs));
             }
         }
 
@@ -91,6 +93,7 @@ namespace triggerCam.LogWriter
             catch (Exception ex)
             {
                 Console.WriteLine($"Error getting total log size: {ex.Message}");
+                global::LogWriter.AddErrorLog(ex, nameof(GetTotalLogSize));
                 return 0;
             }
         }

--- a/SerialTriggerListener.cs
+++ b/SerialTriggerListener.cs
@@ -44,6 +44,7 @@ namespace triggerCam
                     "Platform Not Supported",
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Error);
+                global::LogWriter.AddErrorLog("Platform not supported", nameof(Start));
             }
             catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is InvalidOperationException)
             {
@@ -52,6 +53,7 @@ namespace triggerCam
                     "COMポートエラー",
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Warning);
+                global::LogWriter.AddErrorLog(ex, nameof(Start));
             }
         }
 
@@ -67,7 +69,10 @@ namespace triggerCam
                 else if (line.Equals(stopCommand, StringComparison.OrdinalIgnoreCase))
                     StopReceived?.Invoke();
             }
-            catch { }
+            catch (Exception ex)
+            {
+                global::LogWriter.AddErrorLog(ex, nameof(OnDataReceived));
+            }
         }
 
         public void Dispose()

--- a/Settings/AppSettings.cs
+++ b/Settings/AppSettings.cs
@@ -91,6 +91,11 @@ namespace triggerCam.Settings
         /// </summary>
         public bool UdpEnabled { get; set; } = true;
 
+        /// <summary>
+        /// 録画停止トリガー未検出時のタイムアウト(分)
+        /// </summary>
+        public int RecordingTimeoutMinutes { get; set; } = 10;
+
         // コンストラクタ
         private AppSettings() { }
 
@@ -116,6 +121,7 @@ namespace triggerCam.Settings
             catch (Exception ex)
             {
                 Console.WriteLine($"Error loading settings: {ex.Message}");
+                global::LogWriter.AddErrorLog(ex, nameof(Load));
             }
 
             Console.WriteLine("Using default settings");
@@ -136,6 +142,7 @@ namespace triggerCam.Settings
             catch (Exception ex)
             {
                 Console.WriteLine($"Error saving settings: {ex.Message}");
+                global::LogWriter.AddErrorLog(ex, nameof(Save));
             }
         }
     }

--- a/TrayIcon.cs
+++ b/TrayIcon.cs
@@ -478,13 +478,14 @@ namespace triggerCam
 			if (cameraRecorder != null && !isRecording)
 			{
 				string fileName = DateTime.Now.ToString("yyyyMMdd_HHmmss");
-				Program.SetRecordSource("manual");
-				cameraRecorder.StartRecording(fileName);
-				Program.Notify("manual", "RecStart");
-				isRecording = true;
-				UpdateRecordingState(true);
-			}
-		}
+                               Program.SetRecordSource("manual");
+                               cameraRecorder.StartRecording(fileName);
+                               Program.Notify("manual", "RecStart");
+                               isRecording = true;
+                               UpdateRecordingState(true);
+                               Program.StartRecordingTimeout();
+                        }
+                }
 
 		/// <summary>
 		/// STOPボタンクリック時の処理
@@ -495,12 +496,13 @@ namespace triggerCam
 			var cameraRecorder = Program.GetCameraRecorder();
 			if (cameraRecorder != null && isRecording)
 			{
-				Program.SetRecordSource("manual");
-				cameraRecorder.StopRecording();
-				isRecording = false;
-				UpdateRecordingState(false);
-			}
-		}
+                               Program.SetRecordSource("manual");
+                               cameraRecorder.StopRecording();
+                               isRecording = false;
+                               UpdateRecordingState(false);
+                               Program.StopRecordingTimeout();
+                        }
+                }
 
 		/// <summary>
 		/// 現在選択されているモードを取得 (0:静止画, 1:動画)
@@ -553,10 +555,11 @@ namespace triggerCam
 					});
 				}
 			}
-			catch (Exception ex)
-			{
-				Console.WriteLine($"カメラデバイス一覧の取得エラー: {ex.Message}");
-			}
+                        catch (Exception ex)
+                        {
+                                Console.WriteLine($"カメラデバイス一覧の取得エラー: {ex.Message}");
+                                global::LogWriter.AddErrorLog(ex, "GetCameraDeviceList");
+                        }
 
 			// デバイスが見つからない場合はダミーデータを作成
 			if (cameraList.Count == 0)
@@ -580,10 +583,11 @@ namespace triggerCam
 						}
 					}
 				}
-				catch (Exception ex)
-				{
-					Console.WriteLine($"OpenCVでのカメラ検出エラー: {ex.Message}");
-				}
+                                catch (Exception ex)
+                                {
+                                        Console.WriteLine($"OpenCVでのカメラ検出エラー: {ex.Message}");
+                                        global::LogWriter.AddErrorLog(ex, "GetCameraDeviceList");
+                                }
 			}
 
 			return cameraList;

--- a/UDP/CommandProcessor.cs
+++ b/UDP/CommandProcessor.cs
@@ -286,8 +286,9 @@ namespace triggerCam.UDP
 								}
 								string fullPath = Path.Combine(saveDir, fileName + ".mp4");
 
-								StartRecording(fileName, customPath);
-								Program.Notify("success", "RecStart");
+                                                                StartRecording(fileName, customPath);
+                                                                Program.Notify("success", "RecStart");
+                                                                Program.StartRecordingTimeout();
 								// CameraRecorderクラスでVideoSavedイベントが発火し、実際のファイルパスを含む通知が送信されます
 								//SendResponse(new ResponseData
 								//{
@@ -318,7 +319,8 @@ namespace triggerCam.UDP
 							Program.SetRecordSource("success");
 
 							// 録画を停止（VideoSavedイベントが発生する）
-							StopRecording();
+                                                        StopRecording();
+                                                        Program.StopRecordingTimeout();
 
 							// CameraRecorderクラスでVideoSavedイベントが発火し、実際のファイルパスを含む通知が送信されます
 							//SendResponse(new ResponseData
@@ -595,11 +597,12 @@ namespace triggerCam.UDP
 						break;
 				}
 			}
-			catch (Exception ex)
-			{
-				Console.WriteLine($"Error processing command: {ex.Message}");
-				SendResponse(new ResponseData { status = "error", message = $"Error: {ex.Message}" });
-			}
+                        catch (Exception ex)
+                        {
+                                Console.WriteLine($"Error processing command: {ex.Message}");
+                                global::LogWriter.AddErrorLog(ex, nameof(ProcessCommand));
+                                SendResponse(new ResponseData { status = "error", message = $"Error: {ex.Message}" });
+                        }
 		}
 
 		/// <summary>

--- a/UDP/UDPServer.cs
+++ b/UDP/UDPServer.cs
@@ -73,6 +73,7 @@ public class UDPServer : IDisposable // IDisposable インターフェースを�
         catch (Exception error)
         {
             Console.WriteLine(error.Message, "Receive UDP Data");
+            global::LogWriter.AddErrorLog(error, nameof(ReceiveCallback));
         }
     }
 }

--- a/UDP/UdpAddressChanger.cs
+++ b/UDP/UdpAddressChanger.cs
@@ -17,6 +17,7 @@ namespace triggerCam.UDP
             if (parts.Length != 2)
             {
                 Console.WriteLine("Invalid format. Use IP:Port.");
+                global::LogWriter.AddErrorLog("Invalid UDP address format", nameof(UdpAddressChanger));
                 return;
             }
 
@@ -28,6 +29,7 @@ namespace triggerCam.UDP
             else
             {
                 Console.WriteLine("Invalid IP address.");
+                global::LogWriter.AddErrorLog("Invalid IP address", nameof(UdpAddressChanger));
                 return;
             }
 
@@ -41,12 +43,14 @@ namespace triggerCam.UDP
                 else
                 {
                     Console.WriteLine("Invalid port number. It should be between 0 and 65535.");
+                    global::LogWriter.AddErrorLog("Invalid port number", nameof(UdpAddressChanger));
                     return;
                 }
             }
             else
             {
                 Console.WriteLine("Invalid port number.");
+                global::LogWriter.AddErrorLog("Invalid port number", nameof(UdpAddressChanger));
                 return;
             }
 


### PR DESCRIPTION
## Summary
- show camera disconnected messages via dialog and log
- force stop recording when stop trigger not received
- log errors using `LogWriter.AddErrorLog`
- add recording timeout configuration

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_684bb146f888832793687fac86acf1ae