### PR TITLE
Add configurable serial trigger strings

### DIFF
--- a/Controls/HorizontalMultiControlToolStripItem.cs
+++ b/Controls/HorizontalMultiControlToolStripItem.cs
@@ -105,6 +105,24 @@ namespace triggerCam.Controls
         }
 
         /// <summary>
+        /// TextBoxを追加します
+        /// </summary>
+        /// <param name="width">テキストボックスの幅</param>
+        /// <returns>追加されたTextBox</returns>
+        public TextBox AddTextBox(int width = 100)
+        {
+            var textBox = new TextBox
+            {
+                Width = width,
+                Margin = new Padding(3, 3, 3, 3)
+            };
+
+            _flowPanel.Controls.Add(textBox);
+            _controls.Add(textBox);
+            return textBox;
+        }
+
+        /// <summary>
         /// 指定したインデックスのコントロールを取得します
         /// </summary>
         /// <param name="index">インデックス</param>

--- a/Controls/TriggerStringsControl.cs
+++ b/Controls/TriggerStringsControl.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Windows.Forms;
+
+namespace triggerCam.Controls
+{
+    /// <summary>
+    /// シリアルトリガー文字列を設定するためのコントロール
+    /// </summary>
+    public class TriggerStringsControl : UserControl
+    {
+        private TextBox snapTextBox;
+        private TextBox startTextBox;
+        private TextBox stopTextBox;
+
+        public string SnapTrigger
+        {
+            get => snapTextBox.Text;
+            set => snapTextBox.Text = value;
+        }
+        public string StartTrigger
+        {
+            get => startTextBox.Text;
+            set => startTextBox.Text = value;
+        }
+        public string StopTrigger
+        {
+            get => stopTextBox.Text;
+            set => stopTextBox.Text = value;
+        }
+
+        public event EventHandler? SettingsChanged;
+
+        public TriggerStringsControl()
+        {
+            var panel = new FlowLayoutPanel
+            {
+                AutoSize = true,
+                FlowDirection = FlowDirection.LeftToRight,
+                WrapContents = false,
+                Margin = new Padding(0),
+                Padding = new Padding(0)
+            };
+
+            panel.Controls.Add(new Label
+            {
+                Text = "SNAP:",
+                AutoSize = true,
+                TextAlign = System.Drawing.ContentAlignment.MiddleRight,
+                Margin = new Padding(3, 3, 3, 3)
+            });
+            snapTextBox = new TextBox { Width = 60, Margin = new Padding(3, 3, 3, 3) };
+            snapTextBox.TextChanged += (s, e) => SettingsChanged?.Invoke(this, e);
+            panel.Controls.Add(snapTextBox);
+
+            panel.Controls.Add(new Label
+            {
+                Text = "START:",
+                AutoSize = true,
+                TextAlign = System.Drawing.ContentAlignment.MiddleRight,
+                Margin = new Padding(3, 3, 3, 3)
+            });
+            startTextBox = new TextBox { Width = 60, Margin = new Padding(3, 3, 3, 3) };
+            startTextBox.TextChanged += (s, e) => SettingsChanged?.Invoke(this, e);
+            panel.Controls.Add(startTextBox);
+
+            panel.Controls.Add(new Label
+            {
+                Text = "STOP:",
+                AutoSize = true,
+                TextAlign = System.Drawing.ContentAlignment.MiddleRight,
+                Margin = new Padding(3, 3, 3, 3)
+            });
+            stopTextBox = new TextBox { Width = 60, Margin = new Padding(3, 3, 3, 3) };
+            stopTextBox.TextChanged += (s, e) => SettingsChanged?.Invoke(this, e);
+            panel.Controls.Add(stopTextBox);
+
+            Controls.Add(panel);
+            AutoSize = true;
+            MinimumSize = new System.Drawing.Size(250, 30);
+        }
+    }
+
+    /// <summary>
+    /// ToolStripに配置できるTriggerStringsControl
+    /// </summary>
+    public class TriggerStringsToolStripItem : ToolStripControlHost
+    {
+        public TriggerStringsControl TriggerStringsControl => Control as TriggerStringsControl ?? throw new InvalidOperationException();
+
+        public string SnapTrigger
+        {
+            get => TriggerStringsControl.SnapTrigger;
+            set => TriggerStringsControl.SnapTrigger = value;
+        }
+        public string StartTrigger
+        {
+            get => TriggerStringsControl.StartTrigger;
+            set => TriggerStringsControl.StartTrigger = value;
+        }
+        public string StopTrigger
+        {
+            get => TriggerStringsControl.StopTrigger;
+            set => TriggerStringsControl.StopTrigger = value;
+        }
+
+        public event EventHandler? SettingsChanged
+        {
+            add => TriggerStringsControl.SettingsChanged += value;
+            remove => TriggerStringsControl.SettingsChanged -= value;
+        }
+
+        public TriggerStringsToolStripItem() : base(new TriggerStringsControl())
+        {
+            AutoSize = false;
+            Width = 271;
+            Height = 30;
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -99,7 +99,12 @@ namespace triggerCam
 			Notify("success", "Connected", conData);
 
 			// シリアルトリガーリスナーの初期化
-			serialListener = new SerialTriggerListener(settings.ComPort, settings.BaudRate);
+                        serialListener = new SerialTriggerListener(
+                                        settings.ComPort,
+                                        settings.BaudRate,
+                                        settings.SnapTrigger,
+                                        settings.StartTrigger,
+                                        settings.StopTrigger);
 			serialListener.SnapReceived += () =>
 			{
 				SetSnapshotSource("serial");
@@ -314,14 +319,29 @@ namespace triggerCam
 							i++;
 							break;
 
-						case "--baud":
-						case "-b":
-							if (int.TryParse(value, out int baudRate))
-							{
-								settings.BaudRate = baudRate;
-							}
-							i++;
-							break;
+                                                case "--baud":
+                                                case "-b":
+                                                        if (int.TryParse(value, out int baudRate))
+                                                        {
+                                                                settings.BaudRate = baudRate;
+                                                        }
+                                                        i++;
+                                                        break;
+
+                                                case "--snap":
+                                                        settings.SnapTrigger = value;
+                                                        i++;
+                                                        break;
+
+                                                case "--starttrig":
+                                                        settings.StartTrigger = value;
+                                                        i++;
+                                                        break;
+
+                                                case "--stoptrig":
+                                                        settings.StopTrigger = value;
+                                                        i++;
+                                                        break;
 
 						case "--camera":
 						case "-cam":
@@ -438,6 +458,9 @@ namespace triggerCam
 基本設定:
   --com, -c <ポート名>        シリアルポートを指定 (例: COM1)
   --baud, -b <ボーレート>      ボーレートを指定 (例: 9600)
+  --snap <文字列>             静止画トリガー文字列
+  --starttrig <文字列>        録画開始トリガー文字列
+  --stoptrig <文字列>         録画停止トリガー文字列
   --camera, -cam <インデックス> カメラインデックスを指定 (例: 0)
   --dir, -d <ディレクトリ>     録画・撮影データの保存先を指定
 

--- a/Settings/AppSettings.cs
+++ b/Settings/AppSettings.cs
@@ -38,7 +38,22 @@ namespace triggerCam.Settings
 		/// <summary>
 		/// シリアル通信のボーレート
 		/// </summary>
-		public int BaudRate { get; set; } = 9600;
+                public int BaudRate { get; set; } = 9600;
+
+                /// <summary>
+                /// 静止画撮影トリガー文字列
+                /// </summary>
+                public string SnapTrigger { get; set; } = "SNAP";
+
+                /// <summary>
+                /// 録画開始トリガー文字列
+                /// </summary>
+                public string StartTrigger { get; set; } = "START";
+
+                /// <summary>
+                /// 録画停止トリガー文字列
+                /// </summary>
+                public string StopTrigger { get; set; } = "STOP";
 
 		/// <summary>
 		/// 使用するカメラのインデックス

--- a/TrayIcon.Designer.cs
+++ b/TrayIcon.Designer.cs
@@ -35,8 +35,9 @@ namespace triggerCam
 			this.components = new System.ComponentModel.Container();
 			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TrayIcon));
 			this.context = new ContextMenuStrip(this.components);
-			this.contextMenu_serialContainer = new HorizontalMultiControlToolStripItem();
-			this.contextMenu_cameraControlsContainer = new HorizontalMultiControlToolStripItem();
+                        this.contextMenu_serialContainer = new HorizontalMultiControlToolStripItem();
+                        this.contextMenu_triggerStrings = new TriggerStringsToolStripItem();
+                        this.contextMenu_cameraControlsContainer = new HorizontalMultiControlToolStripItem();
 			this.contextMenu_recordingsDirLabel = new ToolStripMenuItem();
 			this.contextMenu_recordingsPath = new RecordingPathToolStripItem();
 			this.contextMenu_openRecordingsDir = new ToolStripMenuItem();
@@ -55,9 +56,10 @@ namespace triggerCam
 			this.context.AccessibleRole = AccessibleRole.Cursor;
 			this.context.BackColor = SystemColors.Window;
 			this.context.ImageScalingSize = new Size(28, 28);
-			this.context.Items.AddRange(new ToolStripItem[] {
-																												this.contextMenu_serialContainer,
-																												this.contextMenu_cameraControlsContainer,
+                        this.context.Items.AddRange(new ToolStripItem[] {
+                                                                               this.contextMenu_serialContainer,
+                                                                               this.contextMenu_triggerStrings,
+                                                                               this.contextMenu_cameraControlsContainer,
 																												this.contextMenu_recordingsDirLabel,
 																												this.contextMenu_recordingsPath,
 																												this.contextMenu_imageFormatContainer,
@@ -80,8 +82,14 @@ namespace triggerCam
 			this.contextMenu_comPortSelect.SelectedIndexChanged += OnSettingChanged;
 			var labelBaud = this.contextMenu_serialContainer.AddLabel("ボーレート:");
 			this.contextMenu_baudRateSelect = this.contextMenu_serialContainer.AddComboBox(100);
-			this.contextMenu_baudRateSelect.Name = "contextMenu_baudRateSelect";
-			this.contextMenu_baudRateSelect.SelectedIndexChanged += OnSettingChanged;
+                        this.contextMenu_baudRateSelect.Name = "contextMenu_baudRateSelect";
+                        this.contextMenu_baudRateSelect.SelectedIndexChanged += OnSettingChanged;
+
+                        //
+                        // contextMenu_triggerStrings
+                        //
+                        this.contextMenu_triggerStrings.Name = "contextMenu_triggerStrings";
+                        this.contextMenu_triggerStrings.SettingsChanged += OnSettingChanged;
 			//
 			// contextMenu_cameraControlsContainer
 			//
@@ -199,10 +207,11 @@ namespace triggerCam
 		#endregion
 
 		private ContextMenuStrip context;
-		private HorizontalMultiControlToolStripItem contextMenu_serialContainer;
-		private ComboBox contextMenu_comPortSelect;
-		private ComboBox contextMenu_baudRateSelect;
-		private HorizontalMultiControlToolStripItem contextMenu_cameraControlsContainer;
+                private HorizontalMultiControlToolStripItem contextMenu_serialContainer;
+                private ComboBox contextMenu_comPortSelect;
+                private ComboBox contextMenu_baudRateSelect;
+                private TriggerStringsToolStripItem contextMenu_triggerStrings;
+                private HorizontalMultiControlToolStripItem contextMenu_cameraControlsContainer;
 		private Button contextMenu_triggerSnap;
 		private Button contextMenu_triggerStart;
 		private Button contextMenu_triggerStop;

--- a/TrayIcon.cs
+++ b/TrayIcon.cs
@@ -48,9 +48,10 @@ namespace triggerCam
 			contextMenu_cameraSelect.SelectedIndexChanged += OnSettingChanged;
 			contextMenu_modeContainer.SelectedIndexChanged += OnModeChanged;
 			contextMenu_imageFormatContainer.SelectedIndexChanged += OnSettingChanged;
-			contextMenu_udpSettings.AddressChanged += OnAddressChanged;
-			contextMenu_udpSettings.UdpEnabledChanged += contextMenu_udpSettings_CheckedChanged;
-			contextMenu_codecContainer.SelectedIndexChanged += OnSettingChanged;
+                        contextMenu_udpSettings.AddressChanged += OnAddressChanged;
+                        contextMenu_udpSettings.UdpEnabledChanged += contextMenu_udpSettings_CheckedChanged;
+                        contextMenu_triggerStrings.SettingsChanged += OnSettingChanged;
+                        contextMenu_codecContainer.SelectedIndexChanged += OnSettingChanged;
 
 			LoadSettings();
 
@@ -111,9 +112,12 @@ namespace triggerCam
                         int modeIndex = (settings.CaptureMode == 0) ? 0 : 1;
                         contextMenu_modeContainer.SelectedIndex = modeIndex;
 
-			contextMenu_recordingsPath.Path = settings.CameraSaveDirectory;
-			contextMenu_udpSettings.Address = settings.UdpToAddress;
-			contextMenu_udpSettings.UdpEnabled = settings.UdpEnabled;
+                        contextMenu_recordingsPath.Path = settings.CameraSaveDirectory;
+                        contextMenu_udpSettings.Address = settings.UdpToAddress;
+                        contextMenu_udpSettings.UdpEnabled = settings.UdpEnabled;
+                        contextMenu_triggerStrings.SnapTrigger = settings.SnapTrigger;
+                        contextMenu_triggerStrings.StartTrigger = settings.StartTrigger;
+                        contextMenu_triggerStrings.StopTrigger = settings.StopTrigger;
 
 			// モードに応じたフォーマット設定の読み込みはUpdateButtonVisibilityで行う
 
@@ -204,9 +208,12 @@ namespace triggerCam
 			}
 
 			settings.CameraIndex = camIdx;
-			settings.CameraSaveDirectory = contextMenu_recordingsPath.Path;
-			settings.UdpToAddress = contextMenu_udpSettings.Address;
-			settings.UdpEnabled = contextMenu_udpSettings.UdpEnabled;
+                        settings.CameraSaveDirectory = contextMenu_recordingsPath.Path;
+                        settings.UdpToAddress = contextMenu_udpSettings.Address;
+                        settings.UdpEnabled = contextMenu_udpSettings.UdpEnabled;
+                        settings.SnapTrigger = contextMenu_triggerStrings.SnapTrigger;
+                        settings.StartTrigger = contextMenu_triggerStrings.StartTrigger;
+                        settings.StopTrigger = contextMenu_triggerStrings.StopTrigger;
                         // 現在のモードを保存
                         settings.CaptureMode = contextMenu_modeContainer.SelectedIndex;
 


### PR DESCRIPTION
## Summary
- add `TriggerStringsControl` for editing serial trigger strings
- allow setting snap/start/stop triggers via UI and command line
- store trigger strings in `AppSettings`

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68527bde84ec83278cffa5796ebb1af4