### PR TITLE
Fix settings.json loading

### DIFF
--- a/Settings/AppSettings.cs
+++ b/Settings/AppSettings.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace triggerCam.Settings
 {
@@ -126,7 +127,8 @@ namespace triggerCam.Settings
 		public int RecordingTimeoutMinutes { get; set; } = 10;
 
 		// コンストラクタ
-		private AppSettings() { }
+                [JsonConstructor]
+                private AppSettings() { }
 
 		/// <summary>
 		/// 設定を読み込む


### PR DESCRIPTION
## Summary
- add System.Text.Json.Serialization usage
- allow JsonSerializer to use private constructor via `JsonConstructor`

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685287c57d6483279cd5f2e6baf71cb3