### PR TITLE
Improve settings.json discovery

### DIFF
--- a/Settings/AppSettings.cs
+++ b/Settings/AppSettings.cs
@@ -1,4 +1,7 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Diagnostics;
+using System.Collections.Generic;
 
 namespace triggerCam.Settings
 {
@@ -7,8 +10,8 @@ namespace triggerCam.Settings
 	/// </summary>
 	public class AppSettings
 	{
-                private static string settingsFilePath = Path.Combine(
-                                AppDomain.CurrentDomain.BaseDirectory, "settings.json");
+        private static string settingsFilePath = Path.Combine(
+                                AppContext.BaseDirectory, "settings.json");
 
 		// シングルトンインスタンス
 		private static AppSettings? _instance;
@@ -126,21 +129,27 @@ namespace triggerCam.Settings
 		public int RecordingTimeoutMinutes { get; set; } = 10;
 
 		// コンストラクタ
-		private AppSettings() { }
+                [JsonConstructor]
+                private AppSettings() { }
 
 		/// <summary>
 		/// 設定を読み込む
 		/// </summary>
 		/// <returns>読み込んだ設定、またはデフォルト設定</returns>
-		public static AppSettings Load()
-		{
-			try
-			{
-                                string[] paths = new[]
+                public static AppSettings Load()
+                {
+                        try
+                        {
+                                var paths = new List<string>
                                 {
                                         settingsFilePath,
                                         Path.Combine(Environment.CurrentDirectory, "settings.json")
                                 };
+                                if (!string.IsNullOrEmpty(Environment.ProcessPath))
+                                {
+                                        string exeDir = Path.GetDirectoryName(Environment.ProcessPath) ?? string.Empty;
+                                        paths.Add(Path.Combine(exeDir, "settings.json"));
+                                }
 
                                 foreach (var path in paths)
                                 {


### PR DESCRIPTION
## Summary
- better settings.json detection with AppContext and process directory
- search multiple paths when loading settings

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685287c57d6483279cd5f2e6baf71cb3