### PR TITLE
Fix settings.json loading

### DIFF
--- a/Settings/AppSettings.cs
+++ b/Settings/AppSettings.cs
@@ -129,9 +129,8 @@ namespace triggerCam.Settings
 		/// </summary>
 		public int RecordingTimeoutMinutes { get; set; } = 10;
 
-		// コンストラクタ
-                [JsonConstructor]
-                private AppSettings() { }
+                // コンストラクタ
+                public AppSettings() { }
 
 		/// <summary>
 		/// 設定を読み込む


### PR DESCRIPTION
## Summary
- remove JsonConstructor attribute and expose the parameterless constructor of `AppSettings`

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6852917036e483279c41b38c727c5ae8