### PR TITLE
Add UI space for stop trigger

### DIFF
--- a/Controls/TriggerStringsControl.cs
+++ b/Controls/TriggerStringsControl.cs
@@ -76,7 +76,7 @@ namespace triggerCam.Controls
 
             Controls.Add(panel);
             AutoSize = true;
-            MinimumSize = new System.Drawing.Size(250, 30);
+            MinimumSize = new System.Drawing.Size(360, 30);
         }
     }
 
@@ -112,7 +112,7 @@ namespace triggerCam.Controls
         public TriggerStringsToolStripItem() : base(new TriggerStringsControl())
         {
             AutoSize = false;
-            Width = 271;
+            Width = 360;
             Height = 30;
         }
     }


### PR DESCRIPTION
## Summary
- expand TriggerStringsControl width so STOP input fits

## Testing
- `dotnet build -c Release`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685295f562fc83279a19c400ecfef489