### PR TITLE
Fix snapshot file names with millisecond precision

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -182,7 +182,7 @@ namespace triggerCam
 			}
 		}
 
-		private static string CreateFileName() => DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                internal static string CreateFileName() => DateTime.Now.ToString("yyyyMMdd_HHmmss_fff");
 
 		private static void StartUdpServices()
 		{

--- a/TrayIcon.cs
+++ b/TrayIcon.cs
@@ -476,7 +476,7 @@ namespace triggerCam
 			var cameraRecorder = Program.GetCameraRecorder();
 			if (cameraRecorder != null)
 			{
-				string fileName = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                                string fileName = Program.CreateFileName();
 				Program.SetSnapshotSource("manual");
 				cameraRecorder.TakeSnapshot(fileName);
 			}
@@ -491,7 +491,7 @@ namespace triggerCam
 			var cameraRecorder = Program.GetCameraRecorder();
 			if (cameraRecorder != null && !isRecording)
 			{
-				string fileName = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                                string fileName = Program.CreateFileName();
 				Program.SetRecordSource("manual");
 				cameraRecorder.StartRecording(fileName);
 				Program.Notify("manual", "RecStart");

--- a/UDP/CommandProcessor.cs
+++ b/UDP/CommandProcessor.cs
@@ -177,7 +177,7 @@ namespace triggerCam.UDP
 								try
 								{
 									var paramObj = JsonSerializer.Deserialize<Dictionary<string, string>>(command.param);
-									fileName = paramObj?.GetValueOrDefault("fileName") ?? DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                                                                        fileName = paramObj?.GetValueOrDefault("fileName") ?? Program.CreateFileName();
 								}
 								catch
 								{
@@ -187,7 +187,7 @@ namespace triggerCam.UDP
 							}
 							else
 							{
-								fileName = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                                                                fileName = Program.CreateFileName();
 							}
 							Program.SetSnapshotSource("success");
 
@@ -255,7 +255,7 @@ namespace triggerCam.UDP
 									try
 									{
 										var paramObj = JsonSerializer.Deserialize<Dictionary<string, string>>(command.param);
-										fileName = paramObj?.GetValueOrDefault("fileName") ?? DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                                                                               fileName = paramObj?.GetValueOrDefault("fileName") ?? Program.CreateFileName();
 									}
 									catch
 									{
@@ -265,7 +265,7 @@ namespace triggerCam.UDP
 								}
 								else
 								{
-									fileName = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+                                                                        fileName = Program.CreateFileName();
 								}
 								Program.SetRecordSource("success");
 


### PR DESCRIPTION
## Summary
- add milliseconds to `Program.CreateFileName`
- use `Program.CreateFileName` from UI and UDP handlers

## Testing
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68537d7aaea08327874932e87d5c4d43